### PR TITLE
feat(groups): implemented default group handling

### DIFF
--- a/src/main/java/com/sinnerschrader/s2b/accounttool/logic/component/ldap/LdapServiceImpl.java
+++ b/src/main/java/com/sinnerschrader/s2b/accounttool/logic/component/ldap/LdapServiceImpl.java
@@ -664,21 +664,7 @@ public class LdapServiceImpl implements LdapService
 				};
 				throw new BusinessException("LDAP rejected creation of user", "user.create.failed", args);
 			}
-
-			User newUser = getUserByUid(connection, username);
-			List<String> defaultGroupsToAdd = ldapConfiguration.getDefaultGroups();
-			if (defaultGroupsToAdd != null && !defaultGroupsToAdd.isEmpty())
-			{
-				for (String groupCn : defaultGroupsToAdd)
-				{
-					Group group = getGroupByCN(connection, groupCn);
-					if (group != null)
-					{
-						addUserToGroup(connection, newUser, group);
-					}
-				}
-			}
-			return newUser;
+			return getUserByUid(connection, username);
 		}
 		catch (LDAPException le)
 		{

--- a/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/controller/UserController.java
+++ b/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/controller/UserController.java
@@ -193,8 +193,6 @@ public class UserController
 				}
 				if (userForm.isResetpassword())
 				{
-					//
-					//hidePassword = mailService.sendMailForPasswordReset(details, user, password);
 					log.info("{} reseted the password of user {}", details.getUid(), user.getUid());
 					logService.event("logging.logstash.event.user.password-reset",
 						"success", details.getUid(), user.getUid());


### PR DESCRIPTION
implemented add user to default groups on creation or activation. the
user now will be removed on deactivating the account. based on ACL the
user management permission maybe has no permission to add a user to some
groups, this feature is done over a technical management access which
can be restricted for this functionality on ldap server side.