### PR TITLE
feat(bugtracker): added configurable bugtracking url

### DIFF
--- a/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/controller/MainController.java
+++ b/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/controller/MainController.java
@@ -144,7 +144,6 @@ public class MainController
 		model.addObject("applicationContextStartupDate", contextStartupDate);
 		model.addObject("applicationContextRunningSince", new PrettyTime().formatUnrounded(contextStartupDate));
 		model.addObject("activeProfiles", activeProfiles);
-		model.addObject("env", environment);
 		return model;
 	}
 

--- a/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/interceptor/RequestInterceptor.java
+++ b/src/main/java/com/sinnerschrader/s2b/accounttool/presentation/interceptor/RequestInterceptor.java
@@ -42,6 +42,7 @@ public class RequestInterceptor implements HandlerInterceptor
 			!StringUtils.startsWithAny(modelAndView.getViewName(), "redirect:") &&
 			environment != null)
 		{
+			modelAndView.addObject("env", environment);
 			modelAndView.addObject("version", environment.getProperty("app.version"));
 			modelAndView.addObject("rev", environment.getProperty("app.revision"));
 			modelAndView.addObject("time", environment.getProperty("app.build-time"));

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -29,6 +29,13 @@ spring:
 #            enable: "Use StartTLS; default: true"
 
 # =============================================================
+# = Application Settings
+# =============================================================
+#app:
+#  issues: "Custom BugTracking System, for internal useage. Default is set to GitHub Issues URL"
+# Note: Please also create Issues or Feature Requests on GitHub, if you miss something.
+
+# =============================================================
 # = LDAP Configuration (Required)
 # =============================================================
 #ldap:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,7 @@ app:
   build-time: "@git.commit.time@"
   build-by: "@git.commit.user.name@"
   build-on: "@os.name@ (v@os.version@, arch: @os.arch@)"
+  issues: "https://github.com/sinnerschrader/account-tool/issues"
 versions:
   spring-boot: "@project.parent.version@"
   spring-core: "@spring.version@"

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -32,9 +32,9 @@ login.invalid.credentials=Invalid credentials
 login.account.disabled=Your account is disabled. Please contact HR.
 login.general.error=Login was not successfull. Please try again in a few minutes.
 
-user.management.leaving=Leaving employees in the next weeks
+user.management.leaving=Leaving employees in the next {0} weeks
 user.management.unmaintained=Active users who leaved already the company
-user.management.mails=Inactive accounts with E-Mail Account
+user.management.mails=Inactive accounts with active E-Mail Account
 user.management.foundResults=Found {0} accounts for interaction.
 
 # User Modifications of HR

--- a/src/main/resources/public/pages/template/authenticated.html
+++ b/src/main/resources/public/pages/template/authenticated.html
@@ -62,7 +62,7 @@
 					<div class="mdl-mini-footer__right-section">
 						<ul class="mdl-mini-footer__link-list">
 							<li>
-								<a href="https://github.com/sinnerschrader/account-tool/issues" target="_blank">
+								<a href="{{ env.getProperty('app.issues') }}" target="_blank">
 									<i class="material-icons">bug_report</i>
 									<span>Found a Bug?</span>
 								</a>

--- a/src/main/resources/public/pages/template/public.html
+++ b/src/main/resources/public/pages/template/public.html
@@ -52,7 +52,7 @@
 					<div class="mdl-mini-footer__right-section">
 						<ul class="mdl-mini-footer__link-list">
 							<li>
-								<a href="https://github.com/sinnerschrader/account-tool/issues" target="_blank">
+								<a href="{{ env.getProperty('app.issues') }}" target="_blank">
 									<i class="material-icons">bug_report</i>
 									<span>Found a Bug?</span>
 								</a>

--- a/src/main/resources/public/pages/user/maintenance.html
+++ b/src/main/resources/public/pages/user/maintenance.html
@@ -13,7 +13,7 @@
 			<div class="mdl-tabs__panel is-active" id="leaving">
 				<div class="mdl-grid">
 					<div class="mdl-cell mdl-cell--12-col mdl-cell--8-col-tablet mdl-cell--4-col-phone">
-						<h2 class="s2act-sectionHeadline">{{ message('user.management.leaving')}}</h2>
+						<h2 class="s2act-sectionHeadline">{{ message('user.management.leaving', env.getProperty('ldap-management.leavingUsersInCW')) }}</h2>
 						<div class="mdl-list s2act-groupList">
 							{% if leavingUsers is not empty %}
 							<p>{{ message('user.management.foundResults', (leavingUsers | length)) }}</p>


### PR DESCRIPTION
added a config with default to github issues page. this allows to
override the found a bug link on the footer to an internal bugtracking
tool. please keep in mind, that found bugs also reported to public
github, so everybody can participate from this finding. also added
config value on maintenance view, which helps to prioritize the account
maintenance.