### PR TITLE
fix(monitoring): separated monitoring from app security context

### DIFF
--- a/src/main/java/com/sinnerschrader/s2b/accounttool/config/SecurityConfig.java
+++ b/src/main/java/com/sinnerschrader/s2b/accounttool/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter
 	public void configure(WebSecurity web) throws Exception
 	{
 		log.debug("Setting up access for static resources and CSP Report");
-		web.ignoring().antMatchers("/csp-report", "/extensions/**", "/static/**");
+		web.ignoring().antMatchers("/csp-report", "/extensions/**", "/static/**", "/management/**");
 	}
 
 	@Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
     default-encoding: "@project.build.sourceEncoding@"
     from: "accounttool@${domain.primary}"
     reply: "no-reply@${domain.primary}"
-    host: "smtp.{domain.primary}"
+    host: "smtp.${domain.primary}"
     port: "25"
     username:
     password:


### PR DESCRIPTION
removed security context from monitoring urls, because they are bound
internally. fixed also default smtp value for development purpose.